### PR TITLE
Simplify travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 sudo: false
 language: elixir
-script:
-  - mix test
-before_script:
-  - mix local.hex --force
-  - mix deps.get
 after_script:
   - mix deps.get --only docs
   - MIX_ENV=docs mix inch.report


### PR DESCRIPTION
Do not need the parts in travis if using defaults.
