### PR TITLE
Fix warnigs by elixir 1.4.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,11 +6,11 @@ defmodule CreditCard.Mixfile do
      version: "1.0.0",
      description: "A library for validating credit card numbers",
      source_url: "https://github.com/abakhi/credit_card",
-     package: package,
+     package: package(),
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
```
$ mix compile
warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:9

warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:13
```