### PR TITLE
Fix compilation error caused by @card_types attribute on OTP 28 / Elixir 1.18+

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/credit_card.ex
+++ b/lib/credit_card.ex
@@ -2,16 +2,21 @@ defmodule CreditCard do
   @moduledoc """
   Credit card validations library
   """
-  @card_types [
-    visa: ~r/^4[0-9]{12}(?:[0-9]{3})?$/,
-    master_card: ~r/^5[1-5][0-9]{14}$/,
-    maestro:  ~r/(^6759[0-9]{2}([0-9]{10})$)|(^6759[0-9]{2}([0-9]{12})$)|(^6759[0-9]{2}([0-9]{13})$)/,
-    diners_club: ~r/^3(?:0[0-5]|[68][0-9])[0-9]{11}$/,
-    amex: ~r/^3[47][0-9]{13}$/,
-    discover: ~r/^6(?:011|5[0-9]{2})[0-9]{12}$/,
-    jcb: ~r/^(?:2131|1800|35\d{3})\d{11}$/,
-    unionpay: ~r/^62[0-5]\d{13,16}$/
-  ]
+
+  @card_type_keys [:visa, :master_card, :maestro, :diners_club, :amex, :discover, :jcb, :unionpay]
+
+  defp card_types do
+    [
+      visa: ~r/^4[0-9]{12}(?:[0-9]{3})?$/,
+      master_card: ~r/^5[1-5][0-9]{14}$/,
+      maestro:  ~r/(^6759[0-9]{2}([0-9]{10})$)|(^6759[0-9]{2}([0-9]{12})$)|(^6759[0-9]{2}([0-9]{13})$)/,
+      diners_club: ~r/^3(?:0[0-5]|[68][0-9])[0-9]{11}$/,
+      amex: ~r/^3[47][0-9]{13}$/,
+      discover: ~r/^6(?:011|5[0-9]{2})[0-9]{12}$/,
+      jcb: ~r/^(?:2131|1800|35\d{3})\d{11}$/,
+      unionpay: ~r/^62[0-5]\d{13,16}$/
+    ]
+  end
 
   @test_numbers [
     amex: ~w(378282246310005 371449635398431 378734493671000 ),
@@ -28,7 +33,7 @@ defmodule CreditCard do
   ] |> Keyword.values |> List.flatten
 
   @opts %{
-            allowed_card_types: Keyword.keys(@card_types),
+            allowed_card_types: @card_type_keys,
             test_numbers_are_valid: false
         }
 
@@ -126,7 +131,7 @@ defmodule CreditCard do
   """
   @spec card_type(String.t) :: atom | validation_error
   def card_type(number) do
-    card_type = (Keyword.keys(@card_types)
+    card_type = (@card_type_keys
                  |> Enum.filter(&(card_is(strip(number), &1))))
     case card_type do
       [h|_] -> h
@@ -144,35 +149,35 @@ defmodule CreditCard do
 
   @spec card_is(String.t, atom) :: boolean
   def card_is(number, :visa) do
-    @card_types[:visa] |> Regex.match?(number)
+    card_types()[:visa] |> Regex.match?(number)
   end
 
   def card_is(number, :master_card) do
-    @card_types[:master_card] |> Regex.match?(number)
+    card_types()[:master_card] |> Regex.match?(number)
   end
 
   def card_is(number, :maestro) do
-    @card_types[:maestro] |> Regex.match?(number)
+    card_types()[:maestro] |> Regex.match?(number)
   end
 
   def card_is(number, :diners_club) do
-    @card_types[:diners_club] |> Regex.match?(number)
+    card_types()[:diners_club] |> Regex.match?(number)
   end
 
   def card_is(number, :discover) do
-    @card_types[:discover] |> Regex.match?(number)
+    card_types()[:discover] |> Regex.match?(number)
   end
 
   def card_is(number, :amex) do
-    @card_types[:amex] |> Regex.match?(number)
+    card_types()[:amex] |> Regex.match?(number)
   end
 
   def card_is(number, :jcb) do
-    @card_types[:jcb] |> Regex.match?(number)
+    card_types()[:jcb] |> Regex.match?(number)
   end
 
   def card_is(number, :unionpay) do
-    @card_types[:unionpay] |> Regex.match?(number)
+    card_types()[:unionpay] |> Regex.match?(number)
   end
 
   @spec rotate(String.t) :: String.t

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
-%{"earmark": {:hex, :earmark, "0.1.19"},
-  "ex_doc": {:hex, :ex_doc, "0.10.0"},
-  "inch_ex": {:hex, :inch_ex, "0.4.0"},
-  "poison": {:hex, :poison, "1.5.0"}}
+%{
+  "earmark": {:hex, :earmark, "0.1.19", "ffec54f520a11b711532c23d8a52b75a74c09697062d10613fa2dbdf8a9db36e", [:mix], [], "hexpm", "db85f989ba3030d40d3a901d7eebbf926ee07355bf6113d730b8aaf9404a6bd7"},
+  "ex_doc": {:hex, :ex_doc, "0.10.0", "f49c237250b829df986486b38f043e6f8e19d19b41101987f7214543f75947ec", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, repo: "hexpm", optional: true]}], "hexpm", "3d9f15777aa3fb62700d5984eb09ceeb6c1574d61be0f70801e3390e36942b35"},
+  "inch_ex": {:hex, :inch_ex, "0.4.0", "27829de2227edfba8fa5c431088578685c0956128b40522957077963e563e868", [:mix], [{:poison, "~> 1.2", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm", "ddf7ca8ede13624918897398aec29423a163f97328f64a7987899ed71acd69ba"},
+  "poison": {:hex, :poison, "1.5.0", "f2f4f460623a6f154683abae34352525e1d918380267cdbd949a07ba57503248", [:mix], [], "hexpm", "a31ffdaf77494ff12d6c2c9cb03235d4373596d2faf62ee5b99c1ae479618400"},
+}


### PR DESCRIPTION
This PR fixes a compilation error that occurs on OTP 28 (Elixir 1.18+) due to the use of a module attribute containing regex patterns. 

```
== Compilation error in file lib/credit_card.ex ==
** (ArgumentError) cannot inject attribute @card_types into function/macro because cannot escape #Reference<...>. The supported values are: lists, tuples, maps, atoms, numbers, bitstrings, PIDs and remote functions in the format &Mod.fun/arity
    (elixir 1.18.4) lib/kernel.ex:3777: Kernel.do_at_escape/2
    (elixir 1.18.4) expanding macro: Kernel.'1' (see below for file content)
    (credit_card 1.0.0) lib/credit_card.ex:129: CreditCard.card_type/1
    (elixir 1.18.4) expanding macro: Kernel.|>/2
    (credit_card 1.0.0) lib/credit_card.ex:130: CreditCard.card_type/1
```

Additionally, suppresses the following deprecation warning.

```
warning: use Mix.Config is deprecated. Use the Config module instead
  │
  3 │ use Mix.Config
  │ ~~~~~~~~~~~~~~
  │
  └─ config/config.exs:3
```

relates:
https://github.com/elixir-lang/elixir/blob/v1.18/CHANGELOG.md#v1184-2025-05-21
